### PR TITLE
feat: sync Pathbuilder initiative to Roll20 tracker + automate CWS publish

### DIFF
--- a/.github/workflows/publish-chrome-web-store.yml
+++ b/.github/workflows/publish-chrome-web-store.yml
@@ -1,0 +1,71 @@
+name: Publish Chrome extension
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      publish_action:
+        description: 'Chrome Web Store action to run'
+        required: true
+        default: 'publish'
+        type: choice
+        options:
+          - upload
+          - publish
+          - testers
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare zip filename
+        run: |
+          VERSION=$(python3 - <<'PY'
+          import json
+          print(json.load(open('manifest.json'))['version'])
+          PY
+          )
+
+          if [ -n "${GITHUB_REF_NAME:-}" ]; then
+            SAFE_REF="${GITHUB_REF_NAME//\//-}"
+          else
+            SAFE_REF="manual"
+          fi
+
+          ZIP_FILE="path-to-roll-${VERSION}-${SAFE_REF}.zip"
+          echo "ZIP_FILE=$ZIP_FILE" >> "$GITHUB_ENV"
+
+      - name: Build extension zip
+        run: |
+          zip -r "$ZIP_FILE" . \
+            -x ".git/*" ".gitignore" ".github/*" "*.zip"
+
+      - name: Upload zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-extension-package
+          path: ${{ env.ZIP_FILE }}
+
+      - name: Select CWS action
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "CWS_ACTION=${{ inputs.publish_action }}" >> "$GITHUB_ENV"
+          else
+            echo "CWS_ACTION=publish" >> "$GITHUB_ENV"
+          fi
+
+      - name: Upload/publish to Chrome Web Store
+        uses: mobilefirstllc/cws-publish@latest
+        with:
+          action: ${{ env.CWS_ACTION }}
+          client_id: ${{ secrets.CWS_CLIENT_ID }}
+          client_secret: ${{ secrets.CWS_CLIENT_SECRET }}
+          refresh_token: ${{ secrets.CWS_REFRESH_TOKEN }}
+          extension_id: ${{ secrets.CWS_EXTENSION_ID }}
+          zip_file: ${{ env.ZIP_FILE }}

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -142,6 +142,31 @@ Feel free to submit issues and enhancement requests!
    - After approval, the extension will be publicly available
    - Keep your contact information and privacy policy up to date
 
+### CI/CD Publishing (GitHub Actions)
+
+This project includes a ready workflow at:
+
+- `.github/workflows/publish-chrome-web-store.yml`
+
+It uses `mobilefirstllc/cws-publish` to upload/publish directly to Chrome Web Store.
+
+#### Required GitHub Secrets
+
+Add these repository secrets:
+
+- `CWS_CLIENT_ID`
+- `CWS_CLIENT_SECRET`
+- `CWS_REFRESH_TOKEN`
+- `CWS_EXTENSION_ID`
+
+#### Triggers
+
+- Push tag `v*` (for example `v1.0.4`) -> runs with `publish` action
+- Manual run (`workflow_dispatch`) -> lets you choose:
+  - `upload`
+  - `publish`
+  - `testers`
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/manifest.json
+++ b/manifest.json
@@ -33,5 +33,11 @@
       }
     ],
     "permissions": ["clipboardWrite", "activeTab", "tabs", "storage"],
-    "host_permissions": ["https://pathbuilder2e.com/*", "https://app.roll20.net/*"]
+    "host_permissions": ["https://pathbuilder2e.com/*", "https://app.roll20.net/*"],
+    "web_accessible_resources": [
+      {
+        "resources": ["roll20-initiative-bridge.js"],
+        "matches": ["https://app.roll20.net/*"]
+      }
+    ]
 }

--- a/pathbuilder.js
+++ b/pathbuilder.js
@@ -89,16 +89,40 @@ document.addEventListener('click', function(e) {
         let initiativePayload;
 
         if (isInitiativeRoll) {
-            // Roll once here so the chat output and initiative tracker use the same value.
-            const parsedModifier = Number.parseInt(modifier, 10) || 0;
-            const d20 = Math.floor(Math.random() * 20) + 1;
-            const total = d20 + parsedModifier;
+            // Initiative in Pathbuilder is shown as Initiative + Perception.
+            // We combine both modifiers before rolling and sending to Roll20.
+            const initiativeModifierValue = Number.parseInt(modifier, 10) || 0;
 
-            rollString = `&{template:default} {{name=${charName} - ${skillName}}} {{roll=[[${total}]]}} {{modifier=${modifier}}} {{formula=1d20${modifier}}} {{d20=${d20}}}`;
+            const perceptionSkillElement = Array.from(document.querySelectorAll('.section-skill')).find((el) => {
+                const nameEl = el.querySelector('.section-skill-name');
+                return nameEl && nameEl.textContent.trim().toLowerCase() === 'perception';
+            });
+
+            let perceptionModifierText = perceptionSkillElement
+                ? (perceptionSkillElement.querySelector('.section-skill-total')?.textContent.trim() || '+0')
+                : '+0';
+
+            if (!perceptionModifierText.startsWith('+') && !perceptionModifierText.startsWith('-')) {
+                perceptionModifierText = `+${perceptionModifierText}`;
+            }
+
+            const perceptionModifierValue = Number.parseInt(perceptionModifierText, 10) || 0;
+            const combinedModifierValue = initiativeModifierValue + perceptionModifierValue;
+            const combinedModifierText = combinedModifierValue >= 0
+                ? `+${combinedModifierValue}`
+                : `${combinedModifierValue}`;
+
+            // Roll once here so the chat output and initiative tracker use the same value.
+            const d20 = Math.floor(Math.random() * 20) + 1;
+            const total = d20 + combinedModifierValue;
+
+            rollString = `&{template:default} {{name=${charName} - ${skillName}}} {{roll=[[${total}]]}} {{modifier=${combinedModifierText}}} {{initiative mod=${modifier}}} {{perception mod=${perceptionModifierText}}} {{formula=1d20${combinedModifierText}}} {{d20=${d20}}}`;
             initiativePayload = {
                 enabled: true,
                 characterName: charName,
-                modifier: modifier,
+                modifier: combinedModifierText,
+                initiativeModifier: modifier,
+                perceptionModifier: perceptionModifierText,
                 d20,
                 total
             };

--- a/pathbuilder.js
+++ b/pathbuilder.js
@@ -81,11 +81,40 @@ document.addEventListener('click', function(e) {
         console.log('Found character name:', charName);
         const skillName = skillNameElement.textContent.trim();
 
-        // Create the roll template string
-        const rollString = `&{template:default} {{name=${charName} - ${skillName}}} {{roll=[[1d20${modifier}]]}} {{modifier=${modifier}}}`;
+        // Initiative is a special case: if a matching token exists in Roll20,
+        // we'll also try to add the rolled result to the initiative tracker.
+        const isInitiativeRoll = skillName.toLowerCase() === 'initiative';
+
+        let rollString;
+        let initiativePayload;
+
+        if (isInitiativeRoll) {
+            // Roll once here so the chat output and initiative tracker use the same value.
+            const parsedModifier = Number.parseInt(modifier, 10) || 0;
+            const d20 = Math.floor(Math.random() * 20) + 1;
+            const total = d20 + parsedModifier;
+
+            rollString = `&{template:default} {{name=${charName} - ${skillName}}} {{roll=[[${total}]]}} {{modifier=${modifier}}} {{formula=1d20${modifier}}} {{d20=${d20}}}`;
+            initiativePayload = {
+                enabled: true,
+                characterName: charName,
+                modifier: modifier,
+                d20,
+                total
+            };
+        } else {
+            // Default roll behavior for non-initiative skill checks.
+            rollString = `&{template:default} {{name=${charName} - ${skillName}}} {{roll=[[1d20${modifier}]]}} {{modifier=${modifier}}}`;
+        }
 
         // Handle roll string copying and sending
-        handleRollString(rollString, `${skillName} check`, e.clientX, e.clientY);
+        handleRollString(
+            rollString,
+            `${skillName} check`,
+            e.clientX,
+            e.clientY,
+            initiativePayload ? { initiative: initiativePayload } : undefined
+        );
     });
 });
 
@@ -671,7 +700,7 @@ function logHTMLStructure(element) {
 }
 
 // Function to handle roll string copying and sending
-function handleRollString(rollString, description, x, y) {
+function handleRollString(rollString, description, x, y, options = {}) {
     // Get the clipboard preference
     chrome.storage.sync.get(['copyToClipboard'], function(result) {
         const shouldCopy = result.copyToClipboard === true;
@@ -695,13 +724,19 @@ function handleRollString(rollString, description, x, y) {
         actions.push(
             chrome.runtime.sendMessage({
                 type: 'ROLL_STRING',
-                rollString: rollString
+                rollString: rollString,
+                initiative: options?.initiative
             })
             .then(response => {
                 console.log('Background response:', response);
                 if (!response || !response.success) {
                     console.warn('Failed to process roll:', response?.error || 'No response');
                     showPopup('Failed to send to Roll20: ' + (response?.error || 'No response'), x, y);
+                    return;
+                }
+
+                if (response?.initiative && !response.initiative.success) {
+                    console.warn('Initiative tracker update failed:', response.initiative.error);
                 }
             })
             .catch(err => {

--- a/roll20-initiative-bridge.js
+++ b/roll20-initiative-bridge.js
@@ -1,0 +1,232 @@
+(() => {
+    if (window.__pathToRollInitiativeBridgeInstalled) return;
+    window.__pathToRollInitiativeBridgeInstalled = true;
+
+    const INITIATIVE_REQUEST_EVENT = 'path-to-roll:add-initiative';
+    const INITIATIVE_RESULT_EVENT = 'path-to-roll:add-initiative:result';
+
+    const normalize = (value) => (value || '').toString().trim().toLowerCase();
+
+    const parseModifier = (value) => {
+        if (typeof value === 'number' && Number.isFinite(value)) return value;
+        const text = (value || '').toString().trim();
+        const parsed = Number.parseInt(text, 10);
+        return Number.isFinite(parsed) ? parsed : 0;
+    };
+
+    const getCampaign = () => {
+        try {
+            const campaignRef = window.Campaign;
+            if (!campaignRef) return null;
+            return typeof campaignRef === 'function' ? campaignRef() : campaignRef;
+        } catch (error) {
+            return null;
+        }
+    };
+
+    const getD20Campaign = () => {
+        try {
+            const campaignRef = window.d20?.Campaign;
+            if (!campaignRef) return null;
+            return typeof campaignRef === 'function' ? campaignRef() : campaignRef;
+        } catch (error) {
+            return null;
+        }
+    };
+
+    const getModelId = (model) => model?.id || model?.get?.('_id') || model?.get?.('id') || null;
+
+    const listGraphics = (page) => {
+        if (!page) return [];
+
+        const graphics = page.thegraphics;
+        if (!graphics) return [];
+
+        if (Array.isArray(graphics.models)) return graphics.models;
+        if (typeof graphics.models?.toArray === 'function') return graphics.models.toArray();
+        return [];
+    };
+
+    const getActivePages = () => {
+        const pages = [];
+
+        const campaign = getCampaign();
+        const d20Campaign = getD20Campaign();
+
+        try {
+            const activePage =
+                (typeof campaign?.activePage === 'function' ? campaign.activePage() : null)
+                || (typeof d20Campaign?.activePage === 'function' ? d20Campaign.activePage() : null);
+
+            if (activePage) pages.push(activePage);
+        } catch (error) {
+            // ignore
+        }
+
+        try {
+            const playerPageId = campaign?.get?.('playerpageid');
+            const allPages = campaign?.pages?.models || d20Campaign?.pages?.models || [];
+
+            if (playerPageId && Array.isArray(allPages)) {
+                const playerPage = allPages.find(page => getModelId(page) === playerPageId);
+
+                if (playerPage && !pages.includes(playerPage)) {
+                    pages.push(playerPage);
+                }
+            }
+        } catch (error) {
+            // ignore
+        }
+
+        return pages;
+    };
+
+    const findTokenByName = (characterName) => {
+        const targetName = normalize(characterName);
+        if (!targetName) return null;
+
+        const pages = getActivePages();
+        for (const page of pages) {
+            const graphics = listGraphics(page);
+            for (const model of graphics) {
+                try {
+                    const subtype = model?.get?.('_subtype') || model?.attributes?._subtype;
+                    if (subtype && subtype !== 'token') continue;
+
+                    const isDrawing = model?.get?.('isdrawing') || model?.attributes?.isdrawing;
+                    if (isDrawing) continue;
+
+                    const tokenName = model?.get?.('name') || model?.attributes?.name || '';
+                    if (normalize(tokenName) !== targetName) continue;
+
+                    const tokenId = getModelId(model);
+                    if (!tokenId) continue;
+
+                    return {
+                        id: tokenId,
+                        name: tokenName,
+                        pageId: model?.get?.('_pageid') || model?.attributes?._pageid || null
+                    };
+                } catch (error) {
+                    // ignore this token and continue
+                }
+            }
+        }
+
+        return null;
+    };
+
+    const updateTurnOrder = (tokenId, total, pageId) => {
+        const campaign = getCampaign();
+        if (!campaign?.get || !campaign?.set) {
+            return { ok: false, error: 'Campaign API unavailable' };
+        }
+
+        let turnOrder = [];
+        const rawTurnOrder = campaign.get('turnorder');
+
+        if (rawTurnOrder && rawTurnOrder !== '') {
+            try {
+                const parsed = JSON.parse(rawTurnOrder);
+                if (Array.isArray(parsed)) {
+                    turnOrder = parsed;
+                }
+            } catch (error) {
+                // ignore parse errors and reset turn order
+            }
+        }
+
+        const existingIndex = turnOrder.findIndex(entry => entry && entry.id === tokenId);
+        const entry = {
+            id: tokenId,
+            pr: String(total),
+            custom: '',
+            ...(pageId ? { _pageid: pageId } : {})
+        };
+
+        if (existingIndex >= 0) {
+            turnOrder[existingIndex] = {
+                ...turnOrder[existingIndex],
+                ...entry
+            };
+        } else {
+            turnOrder.push(entry);
+        }
+
+        turnOrder.sort((a, b) => (Number.parseFloat(b?.pr) || 0) - (Number.parseFloat(a?.pr) || 0));
+        campaign.set('turnorder', JSON.stringify(turnOrder));
+
+        if (pageId) {
+            try {
+                campaign.set('initiativepage', pageId);
+            } catch (error) {
+                // ignore if unavailable in this context
+            }
+        }
+
+        return { ok: true };
+    };
+
+    const addInitiative = (payload = {}) => {
+        const characterName = (payload.characterName || '').toString().trim();
+        if (!characterName) {
+            return { success: false, error: 'Missing character name' };
+        }
+
+        const token = findTokenByName(characterName);
+        if (!token) {
+            return {
+                success: false,
+                error: 'No token with matching name found on the active Roll20 page',
+                characterName
+            };
+        }
+
+        const modifier = parseModifier(payload.modifier);
+
+        const providedD20 = Number.parseInt(payload.d20, 10);
+        const providedTotal = Number.parseInt(payload.total, 10);
+
+        const roll = Number.isFinite(providedD20)
+            ? providedD20
+            : Math.floor(Math.random() * 20) + 1;
+
+        const total = Number.isFinite(providedTotal)
+            ? providedTotal
+            : (roll + modifier);
+
+        const turnOrderResult = updateTurnOrder(token.id, total, token.pageId);
+        if (!turnOrderResult.ok) {
+            return { success: false, error: turnOrderResult.error };
+        }
+
+        return {
+            success: true,
+            characterName,
+            tokenName: token.name,
+            tokenId: token.id,
+            roll,
+            modifier,
+            total
+        };
+    };
+
+    window.addEventListener(INITIATIVE_REQUEST_EVENT, (event) => {
+        const detail = event?.detail || {};
+        const requestId = detail.requestId;
+
+        let result;
+        try {
+            result = addInitiative(detail.payload || {});
+        } catch (error) {
+            result = {
+                success: false,
+                error: error?.message || String(error)
+            };
+        }
+
+        window.dispatchEvent(new CustomEvent(INITIATIVE_RESULT_EVENT, {
+            detail: { requestId, result }
+        }));
+    });
+})();

--- a/roll20.js
+++ b/roll20.js
@@ -3,237 +3,59 @@ console.log('Roll20 helper script loaded');
 
 const INITIATIVE_REQUEST_EVENT = 'path-to-roll:add-initiative';
 const INITIATIVE_RESULT_EVENT = 'path-to-roll:add-initiative:result';
-let initiativeBridgeInjected = false;
+let initiativeBridgeReadyPromise = null;
 
-function injectInitiativeBridge() {
-    if (initiativeBridgeInjected) return;
-
-    const existingBridge = document.querySelector('script[data-path-to-roll="initiative-bridge"]');
-    if (existingBridge) {
-        initiativeBridgeInjected = true;
-        return;
+function ensureInitiativeBridge() {
+    if (initiativeBridgeReadyPromise) {
+        return initiativeBridgeReadyPromise;
     }
 
-    const script = document.createElement('script');
-    script.dataset.pathToRoll = 'initiative-bridge';
-    script.textContent = `
-(() => {
-    if (window.__pathToRollInitiativeBridgeInstalled) return;
-    window.__pathToRollInitiativeBridgeInstalled = true;
+    initiativeBridgeReadyPromise = new Promise((resolve, reject) => {
+        const existingBridge = document.querySelector('script[data-path-to-roll="initiative-bridge"]');
 
-    const normalize = (value) => (value || '').toString().trim().toLowerCase();
-
-    const parseModifier = (value) => {
-        if (typeof value === 'number' && Number.isFinite(value)) return value;
-        const text = (value || '').toString().trim();
-        const parsed = Number.parseInt(text, 10);
-        return Number.isFinite(parsed) ? parsed : 0;
-    };
-
-    const listGraphics = (page) => {
-        if (!page) return [];
-
-        const graphics = page.thegraphics;
-        if (!graphics) return [];
-
-        if (Array.isArray(graphics.models)) return graphics.models;
-        if (typeof graphics.models?.toArray === 'function') return graphics.models.toArray();
-        return [];
-    };
-
-    const getActivePages = () => {
-        const pages = [];
-
-        try {
-            const activePage = window.d20?.Campaign?.activePage?.();
-            if (activePage) pages.push(activePage);
-        } catch (error) {
-            // ignore
-        }
-
-        try {
-            const campaign = window.Campaign?.();
-            const playerPageId = campaign?.get?.('playerpageid');
-            const allPages = window.d20?.Campaign?.pages?.models;
-
-            if (playerPageId && Array.isArray(allPages)) {
-                const playerPage = allPages.find(page => {
-                    if (!page) return false;
-                    const id = page.id || page.get?.('id') || page.get?.('_id');
-                    return id === playerPageId;
-                });
-
-                if (playerPage && !pages.includes(playerPage)) {
-                    pages.push(playerPage);
-                }
+        if (existingBridge) {
+            if (existingBridge.dataset.loaded === 'true') {
+                resolve();
+                return;
             }
-        } catch (error) {
-            // ignore
+
+            existingBridge.addEventListener('load', () => {
+                existingBridge.dataset.loaded = 'true';
+                resolve();
+            }, { once: true });
+
+            existingBridge.addEventListener('error', () => {
+                reject(new Error('Failed to load initiative bridge script'));
+            }, { once: true });
+
+            return;
         }
 
-        return pages;
-    };
+        const script = document.createElement('script');
+        script.dataset.pathToRoll = 'initiative-bridge';
+        script.src = chrome.runtime.getURL('roll20-initiative-bridge.js');
 
-    const findTokenByName = (characterName) => {
-        const targetName = normalize(characterName);
-        if (!targetName) return null;
+        script.addEventListener('load', () => {
+            script.dataset.loaded = 'true';
+            resolve();
+        }, { once: true });
 
-        const pages = getActivePages();
-        for (const page of pages) {
-            const graphics = listGraphics(page);
-            for (const model of graphics) {
-                try {
-                    const subtype = model?.get?.('_subtype') || model?.attributes?._subtype;
-                    if (subtype && subtype !== 'token') continue;
+        script.addEventListener('error', () => {
+            reject(new Error('Failed to load initiative bridge script'));
+        }, { once: true });
 
-                    const isDrawing = model?.get?.('isdrawing') || model?.attributes?.isdrawing;
-                    if (isDrawing) continue;
-
-                    const tokenName = model?.get?.('name') || model?.attributes?.name || '';
-                    if (normalize(tokenName) !== targetName) continue;
-
-                    const tokenId = model?.id || model?.get?.('_id') || model?.get?.('id');
-                    if (!tokenId) continue;
-
-                    return {
-                        id: tokenId,
-                        name: tokenName,
-                        pageId: model?.get?.('_pageid') || model?.attributes?._pageid || null
-                    };
-                } catch (error) {
-                    // ignore this token and continue
-                }
-            }
-        }
-
-        return null;
-    };
-
-    const updateTurnOrder = (tokenId, total, pageId) => {
-        const campaign = window.Campaign?.();
-        if (!campaign?.get || !campaign?.set) {
-            return { ok: false, error: 'Campaign API unavailable' };
-        }
-
-        let turnOrder = [];
-        const rawTurnOrder = campaign.get('turnorder');
-
-        if (rawTurnOrder && rawTurnOrder !== '') {
-            try {
-                const parsed = JSON.parse(rawTurnOrder);
-                if (Array.isArray(parsed)) {
-                    turnOrder = parsed;
-                }
-            } catch (error) {
-                // ignore parse errors and reset turn order
-            }
-        }
-
-        const existingIndex = turnOrder.findIndex(entry => entry && entry.id === tokenId);
-        const entry = {
-            id: tokenId,
-            pr: String(total),
-            custom: ''
-        };
-
-        if (existingIndex >= 0) {
-            turnOrder[existingIndex] = {
-                ...turnOrder[existingIndex],
-                ...entry
-            };
-        } else {
-            turnOrder.push(entry);
-        }
-
-        turnOrder.sort((a, b) => (Number.parseFloat(b?.pr) || 0) - (Number.parseFloat(a?.pr) || 0));
-        campaign.set('turnorder', JSON.stringify(turnOrder));
-
-        // If available, set the initiative page so tracker is associated with this page.
-        if (pageId) {
-            try {
-                campaign.set('initiativepage', pageId);
-            } catch (error) {
-                // ignore if unavailable in this context
-            }
-        }
-
-        return { ok: true };
-    };
-
-    const addInitiative = (payload = {}) => {
-        const characterName = (payload.characterName || '').toString().trim();
-        if (!characterName) {
-            return { success: false, error: 'Missing character name' };
-        }
-
-        const token = findTokenByName(characterName);
-        if (!token) {
-            return {
-                success: false,
-                error: 'No token with matching name found on the active Roll20 page',
-                characterName
-            };
-        }
-
-        const modifier = parseModifier(payload.modifier);
-
-        const providedD20 = Number.parseInt(payload.d20, 10);
-        const providedTotal = Number.parseInt(payload.total, 10);
-
-        const roll = Number.isFinite(providedD20)
-            ? providedD20
-            : Math.floor(Math.random() * 20) + 1;
-
-        const total = Number.isFinite(providedTotal)
-            ? providedTotal
-            : (roll + modifier);
-
-        const turnOrderResult = updateTurnOrder(token.id, total, token.pageId);
-        if (!turnOrderResult.ok) {
-            return { success: false, error: turnOrderResult.error };
-        }
-
-        return {
-            success: true,
-            characterName,
-            tokenName: token.name,
-            tokenId: token.id,
-            roll,
-            modifier,
-            total
-        };
-    };
-
-    window.addEventListener('${INITIATIVE_REQUEST_EVENT}', (event) => {
-        const detail = event?.detail || {};
-        const requestId = detail.requestId;
-
-        let result;
-        try {
-            result = addInitiative(detail.payload || {});
-        } catch (error) {
-            result = {
-                success: false,
-                error: error?.message || String(error)
-            };
-        }
-
-        window.dispatchEvent(new CustomEvent('${INITIATIVE_RESULT_EVENT}', {
-            detail: { requestId, result }
-        }));
+        (document.head || document.documentElement).appendChild(script);
+    }).catch((error) => {
+        // Allow retry on next request if loading failed.
+        initiativeBridgeReadyPromise = null;
+        throw error;
     });
-})();
-`;
 
-    (document.head || document.documentElement).appendChild(script);
-    script.remove();
-    initiativeBridgeInjected = true;
+    return initiativeBridgeReadyPromise;
 }
 
 function addInitiativeToTracker(initiativePayload) {
-    injectInitiativeBridge();
-
-    return new Promise((resolve) => {
+    return ensureInitiativeBridge().then(() => new Promise((resolve) => {
         const requestId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
         const onResult = (event) => {
@@ -258,7 +80,7 @@ function addInitiativeToTracker(initiativePayload) {
                 payload: initiativePayload
             }
         }));
-    });
+    }));
 }
 
 // Listen for messages from the Pathbuilder page
@@ -275,7 +97,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         console.log('Processing roll string:', message.rollString);
 
         // Try to find the chat input
-        const chatInput = document.querySelector("#textchat-input > textarea");
+        const chatInput = document.querySelector('#textchat-input > textarea');
         console.log('Found chat input:', !!chatInput);
 
         if (chatInput) {
@@ -301,7 +123,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 console.log('Focused chat input');
 
                 // Try to submit the roll
-                const sendButton = document.querySelector("#chatSendBtn");
+                const sendButton = document.querySelector('#chatSendBtn');
                 if (sendButton) {
                     console.log('Found send button, clicking it');
                     sendButton.click();

--- a/roll20.js
+++ b/roll20.js
@@ -1,6 +1,266 @@
 // Log that the script has loaded
 console.log('Roll20 helper script loaded');
 
+const INITIATIVE_REQUEST_EVENT = 'path-to-roll:add-initiative';
+const INITIATIVE_RESULT_EVENT = 'path-to-roll:add-initiative:result';
+let initiativeBridgeInjected = false;
+
+function injectInitiativeBridge() {
+    if (initiativeBridgeInjected) return;
+
+    const existingBridge = document.querySelector('script[data-path-to-roll="initiative-bridge"]');
+    if (existingBridge) {
+        initiativeBridgeInjected = true;
+        return;
+    }
+
+    const script = document.createElement('script');
+    script.dataset.pathToRoll = 'initiative-bridge';
+    script.textContent = `
+(() => {
+    if (window.__pathToRollInitiativeBridgeInstalled) return;
+    window.__pathToRollInitiativeBridgeInstalled = true;
+
+    const normalize = (value) => (value || '').toString().trim().toLowerCase();
+
+    const parseModifier = (value) => {
+        if (typeof value === 'number' && Number.isFinite(value)) return value;
+        const text = (value || '').toString().trim();
+        const parsed = Number.parseInt(text, 10);
+        return Number.isFinite(parsed) ? parsed : 0;
+    };
+
+    const listGraphics = (page) => {
+        if (!page) return [];
+
+        const graphics = page.thegraphics;
+        if (!graphics) return [];
+
+        if (Array.isArray(graphics.models)) return graphics.models;
+        if (typeof graphics.models?.toArray === 'function') return graphics.models.toArray();
+        return [];
+    };
+
+    const getActivePages = () => {
+        const pages = [];
+
+        try {
+            const activePage = window.d20?.Campaign?.activePage?.();
+            if (activePage) pages.push(activePage);
+        } catch (error) {
+            // ignore
+        }
+
+        try {
+            const campaign = window.Campaign?.();
+            const playerPageId = campaign?.get?.('playerpageid');
+            const allPages = window.d20?.Campaign?.pages?.models;
+
+            if (playerPageId && Array.isArray(allPages)) {
+                const playerPage = allPages.find(page => {
+                    if (!page) return false;
+                    const id = page.id || page.get?.('id') || page.get?.('_id');
+                    return id === playerPageId;
+                });
+
+                if (playerPage && !pages.includes(playerPage)) {
+                    pages.push(playerPage);
+                }
+            }
+        } catch (error) {
+            // ignore
+        }
+
+        return pages;
+    };
+
+    const findTokenByName = (characterName) => {
+        const targetName = normalize(characterName);
+        if (!targetName) return null;
+
+        const pages = getActivePages();
+        for (const page of pages) {
+            const graphics = listGraphics(page);
+            for (const model of graphics) {
+                try {
+                    const subtype = model?.get?.('_subtype') || model?.attributes?._subtype;
+                    if (subtype && subtype !== 'token') continue;
+
+                    const isDrawing = model?.get?.('isdrawing') || model?.attributes?.isdrawing;
+                    if (isDrawing) continue;
+
+                    const tokenName = model?.get?.('name') || model?.attributes?.name || '';
+                    if (normalize(tokenName) !== targetName) continue;
+
+                    const tokenId = model?.id || model?.get?.('_id') || model?.get?.('id');
+                    if (!tokenId) continue;
+
+                    return {
+                        id: tokenId,
+                        name: tokenName,
+                        pageId: model?.get?.('_pageid') || model?.attributes?._pageid || null
+                    };
+                } catch (error) {
+                    // ignore this token and continue
+                }
+            }
+        }
+
+        return null;
+    };
+
+    const updateTurnOrder = (tokenId, total, pageId) => {
+        const campaign = window.Campaign?.();
+        if (!campaign?.get || !campaign?.set) {
+            return { ok: false, error: 'Campaign API unavailable' };
+        }
+
+        let turnOrder = [];
+        const rawTurnOrder = campaign.get('turnorder');
+
+        if (rawTurnOrder && rawTurnOrder !== '') {
+            try {
+                const parsed = JSON.parse(rawTurnOrder);
+                if (Array.isArray(parsed)) {
+                    turnOrder = parsed;
+                }
+            } catch (error) {
+                // ignore parse errors and reset turn order
+            }
+        }
+
+        const existingIndex = turnOrder.findIndex(entry => entry && entry.id === tokenId);
+        const entry = {
+            id: tokenId,
+            pr: String(total),
+            custom: ''
+        };
+
+        if (existingIndex >= 0) {
+            turnOrder[existingIndex] = {
+                ...turnOrder[existingIndex],
+                ...entry
+            };
+        } else {
+            turnOrder.push(entry);
+        }
+
+        turnOrder.sort((a, b) => (Number.parseFloat(b?.pr) || 0) - (Number.parseFloat(a?.pr) || 0));
+        campaign.set('turnorder', JSON.stringify(turnOrder));
+
+        // If available, set the initiative page so tracker is associated with this page.
+        if (pageId) {
+            try {
+                campaign.set('initiativepage', pageId);
+            } catch (error) {
+                // ignore if unavailable in this context
+            }
+        }
+
+        return { ok: true };
+    };
+
+    const addInitiative = (payload = {}) => {
+        const characterName = (payload.characterName || '').toString().trim();
+        if (!characterName) {
+            return { success: false, error: 'Missing character name' };
+        }
+
+        const token = findTokenByName(characterName);
+        if (!token) {
+            return {
+                success: false,
+                error: 'No token with matching name found on the active Roll20 page',
+                characterName
+            };
+        }
+
+        const modifier = parseModifier(payload.modifier);
+
+        const providedD20 = Number.parseInt(payload.d20, 10);
+        const providedTotal = Number.parseInt(payload.total, 10);
+
+        const roll = Number.isFinite(providedD20)
+            ? providedD20
+            : Math.floor(Math.random() * 20) + 1;
+
+        const total = Number.isFinite(providedTotal)
+            ? providedTotal
+            : (roll + modifier);
+
+        const turnOrderResult = updateTurnOrder(token.id, total, token.pageId);
+        if (!turnOrderResult.ok) {
+            return { success: false, error: turnOrderResult.error };
+        }
+
+        return {
+            success: true,
+            characterName,
+            tokenName: token.name,
+            tokenId: token.id,
+            roll,
+            modifier,
+            total
+        };
+    };
+
+    window.addEventListener('${INITIATIVE_REQUEST_EVENT}', (event) => {
+        const detail = event?.detail || {};
+        const requestId = detail.requestId;
+
+        let result;
+        try {
+            result = addInitiative(detail.payload || {});
+        } catch (error) {
+            result = {
+                success: false,
+                error: error?.message || String(error)
+            };
+        }
+
+        window.dispatchEvent(new CustomEvent('${INITIATIVE_RESULT_EVENT}', {
+            detail: { requestId, result }
+        }));
+    });
+})();
+`;
+
+    (document.head || document.documentElement).appendChild(script);
+    script.remove();
+    initiativeBridgeInjected = true;
+}
+
+function addInitiativeToTracker(initiativePayload) {
+    injectInitiativeBridge();
+
+    return new Promise((resolve) => {
+        const requestId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+        const onResult = (event) => {
+            const detail = event?.detail;
+            if (!detail || detail.requestId !== requestId) return;
+
+            window.removeEventListener(INITIATIVE_RESULT_EVENT, onResult);
+            clearTimeout(timeoutId);
+            resolve(detail.result || { success: false, error: 'No result payload from initiative bridge' });
+        };
+
+        const timeoutId = setTimeout(() => {
+            window.removeEventListener(INITIATIVE_RESULT_EVENT, onResult);
+            resolve({ success: false, error: 'Timed out while updating initiative tracker' });
+        }, 2000);
+
+        window.addEventListener(INITIATIVE_RESULT_EVENT, onResult);
+
+        window.dispatchEvent(new CustomEvent(INITIATIVE_REQUEST_EVENT, {
+            detail: {
+                requestId,
+                payload: initiativePayload
+            }
+        }));
+    });
+}
+
 // Listen for messages from the Pathbuilder page
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     console.log('Received message in Roll20:', message);
@@ -20,9 +280,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
         if (chatInput) {
             try {
-                // Store the original value to verify the change
-                const originalValue = chatInput.value;
-
                 // Set the value and trigger an input event
                 chatInput.value = message.rollString;
                 console.log('Set chat input value to:', message.rollString);
@@ -44,7 +301,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 console.log('Focused chat input');
 
                 // Try to submit the roll
-                // First try the send button
                 const sendButton = document.querySelector("#chatSendBtn");
                 if (sendButton) {
                     console.log('Found send button, clicking it');
@@ -61,19 +317,36 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                     }));
                 }
 
-                // Verify everything worked
-                if (document.activeElement === chatInput) {
-                    console.log('Roll string successfully submitted');
-                    sendResponse({ success: true });
-                } else {
-                    console.warn('Something went wrong after setting the value');
-                    sendResponse({
-                        success: false,
-                        error: 'Verification failed',
-                        activeElement: document.activeElement === chatInput,
-                        valueMatch: chatInput.value === message.rollString
-                    });
+                // Optionally update initiative tracker if this roll is an initiative roll
+                if (message?.initiative?.enabled) {
+                    addInitiativeToTracker(message.initiative)
+                        .then((initiativeResult) => {
+                            if (!initiativeResult?.success) {
+                                console.warn('Failed to update initiative tracker:', initiativeResult?.error);
+                            } else {
+                                console.log('Initiative tracker updated:', initiativeResult);
+                            }
+
+                            sendResponse({
+                                success: true,
+                                initiative: initiativeResult
+                            });
+                        })
+                        .catch((error) => {
+                            console.warn('Initiative tracker update threw an error:', error);
+                            sendResponse({
+                                success: true,
+                                initiative: {
+                                    success: false,
+                                    error: error?.message || String(error)
+                                }
+                            });
+                        });
+
+                    return true;
                 }
+
+                sendResponse({ success: true });
             } catch (error) {
                 console.error('Error while setting roll string:', error);
                 sendResponse({ success: false, error: error.message });
@@ -87,5 +360,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         console.log('Unknown message type:', message.type);
         sendResponse({ success: false, error: 'Unknown message type' });
     }
-    return true; // Keep the message channel open for the async response
+
+    return true; // Keep the message channel open for async responses
 });


### PR DESCRIPTION
## What's included

### Initiative sync improvements
- Add Roll20 initiative tracker update when rolling **Initiative** from Pathbuilder
- Match Roll20 token by character name (case-insensitive)
- Update existing turn-order entry if present, otherwise add a new one

### Correct initiative math
- Use **Initiative modifier + Perception modifier** from Pathbuilder
- Example for Тайозан: `+0 + +15 = +15`
- Keep chat roll and tracker value in sync by rolling once and reusing the same total

### Better Roll20 card visibility
- Include explicit fields in the chat card:
  - `Initiative mod`
  - `Perception mod`
  - combined `Modifier`

### CSP-safe bridge injection
- Replace blocked inline script injection with external bridge file:
  - `roll20-initiative-bridge.js`
- Expose it via `web_accessible_resources` in `manifest.json`

### Chrome Web Store publishing automation
- Add GitHub Actions workflow:
  - `.github/workflows/publish-chrome-web-store.yml`
- Supports:
  - tag push `v*` -> publish
  - manual dispatch -> upload/publish/testers
- Uses `mobilefirstllc/cws-publish`

### Docs
- Update README with required secrets and trigger instructions for CWS CI/CD

## Validation
- `node --check pathbuilder.js`
- `node --check roll20.js`
- `node --check roll20-initiative-bridge.js`
- Live browser verification (Pathbuilder + Roll20):
  - initiative click sends chat message
  - tracker entry for "Тайозан" updates
  - card shows explicit modifier breakdown